### PR TITLE
Add default debugging setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,3 @@ pip-log.txt
 .DS_Store
 .idea/*
 .python-version
-.vscode/*

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Current File",
+            "type": "python",
+            "request": "launch",
+            "program": "chessington/app.py",
+            "console": "integratedTerminal"
+        },
+        {
+            "name": "Python: Current File",
+            "type": "python",
+            "request": "test",
+            "console": "integratedTerminal"
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "python.testing.pytestArgs": [
+        "."
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.nosetestsEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,13 @@ Running the tests
 To run the tests, use the command ``poetry run pytest tests``. This will run any test defined in a function
 matching the pattern ``test_*`` or ``*_test``, in any file matching the same patterns, in the ``tests`` directory.
 
+Debugging
+----------------
+VSCode debug config has been set up, but you will need to select your virtual environments python interpreter
+before running either the tests or app in debug mode. You can do this in VS Code by going to `View`->`Command Palette`,
+searching for `Python: Select Interpreter` and then browse your machine to find the appropriate python executable (e.g. 
+`.venv\Scripts\python.exe` or `.venv\Scripts\python`)
+
 GUI Dependencies
 ----------------
 

--- a/chessington/app.py
+++ b/chessington/app.py
@@ -1,0 +1,3 @@
+from chessington.ui import play_game
+
+play_game()


### PR DESCRIPTION
Add some setup to simplify the debugging setup process, added an instruction to the readme for the remaining setup required to get that working in VSCode

Needs to be verified with a Mac before it should be merged
Edit: Have verified that it just works with mac for the tests, and I just needed to also follow the tlc-tk setup mentioned in the readme to get the debugging working